### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/examples/MonkeyTrap/src/trap/AnimationFactories.java
+++ b/examples/MonkeyTrap/src/trap/AnimationFactories.java
@@ -54,8 +54,11 @@ import static trap.anim.AnimInterpolators.*;
 public class AnimationFactories {
  
     private static AssetManager assets;
-    
-    public static void initialize( AssetManager assets ) {
+
+    private AnimationFactories() {
+    }
+
+    public static void initialize(AssetManager assets ) {
         AnimationFactories.assets = assets;
     }
 

--- a/examples/MonkeyTrap/src/trap/MaterialUtils.java
+++ b/examples/MonkeyTrap/src/trap/MaterialUtils.java
@@ -47,7 +47,10 @@ import com.jme3.scene.Spatial;
  */
 public class MaterialUtils {
 
-    public static void setColor( Spatial s, String materialAssetName, String parm, ColorRGBA value ) {
+    private MaterialUtils() {
+    }
+
+    public static void setColor(Spatial s, String materialAssetName, String parm, ColorRGBA value ) {
         if( s instanceof Node ) {
             Node n = (Node)s;
             for( Spatial child : n.getChildren() ) {

--- a/examples/MonkeyTrap/src/trap/MeshGenerator.java
+++ b/examples/MonkeyTrap/src/trap/MeshGenerator.java
@@ -51,6 +51,9 @@ import java.util.List;
  */
 public class MeshGenerator
 {
+    private MeshGenerator() {
+    }
+
     private static float[][] wallVerts = {
     
                 // North (facing south)

--- a/examples/MonkeyTrap/src/trap/anim/AnimInterpolators.java
+++ b/examples/MonkeyTrap/src/trap/anim/AnimInterpolators.java
@@ -50,7 +50,10 @@ import trap.task.Interpolator;
  */
 public class AnimInterpolators {
 
-    public static Interpolator move( Spatial s, Vector3f start, Vector3f end ) {
+    private AnimInterpolators() {
+    }
+
+    public static Interpolator move(Spatial s, Vector3f start, Vector3f end ) {
         return new MoveSpatial(s, start, end);
     }
 

--- a/examples/MonkeyTrap/src/trap/anim/SpatialTaskFactories.java
+++ b/examples/MonkeyTrap/src/trap/anim/SpatialTaskFactories.java
@@ -47,8 +47,11 @@ import trap.task.Task;
  *  @author    Paul Speed
  */
 public class SpatialTaskFactories {
-    
-    public static SpatialTaskFactory singleton( Task task ) {
+
+    private SpatialTaskFactories() {
+    }
+
+    public static SpatialTaskFactory singleton(Task task ) {
         return new SingletonFactory(task);
     }
 

--- a/examples/MonkeyTrap/src/trap/game/EntityFactories.java
+++ b/examples/MonkeyTrap/src/trap/game/EntityFactories.java
@@ -49,8 +49,11 @@ import com.simsilica.es.EntityId;
  */
 public class EntityFactories {
     private static EntityData ed;
- 
-    public static void initialize( EntityData ed ) {
+
+    private EntityFactories() {
+    }
+
+    public static void initialize(EntityData ed ) {
         EntityFactories.ed = ed;                
     }
     

--- a/examples/MonkeyTrap/src/trap/task/Interpolators.java
+++ b/examples/MonkeyTrap/src/trap/task/Interpolators.java
@@ -48,6 +48,9 @@ import java.util.List;
  */
 public class Interpolators {
 
+    private Interpolators() {
+    }
+
     /**
      *  Composes a list of interpolators together such that they
      *  run in parallel.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
