### PR TITLE
Java8 compiles javadoc with errors, because of stricter doclint

### DIFF
--- a/extensions/Zay-ES-Net/build.gradle
+++ b/extensions/Zay-ES-Net/build.gradle
@@ -40,6 +40,13 @@ artifacts {
     archives javadocJar
 }
 
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+ }
 
 // Put this at the end or it won't pick up the project.version and stuff
 // ...thus it also can't be injected.  But that means we can also be selective

--- a/extensions/Zay-ES-Net/build.xml
+++ b/extensions/Zay-ES-Net/build.xml
@@ -11,20 +11,6 @@
     <description>Builds, tests, and runs the project Zay-ES-Net.</description>
     <import file="nbproject/build-impl.xml"/>
     
-    <!-- Added disable of strict java comple for javadoc, for java8 -->
-    <profiles>
-        <profile>
-            <id>disable-java8-doclint</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <properties>
-                <additionalparam>-Xdoclint:none</additionalparam>
-            </properties>
-        </profile>
-    </profiles>
-    <!--
-
     There exist several targets which are by default empty and which can be 
     used for execution of your tasks. These targets are usually executed 
     before and after some main targets. They are: 

--- a/extensions/Zay-ES-Net/build.xml
+++ b/extensions/Zay-ES-Net/build.xml
@@ -10,6 +10,19 @@
 <project name="Zay-ES-Net" default="default" basedir=".">
     <description>Builds, tests, and runs the project Zay-ES-Net.</description>
     <import file="nbproject/build-impl.xml"/>
+    
+    <!-- Added disable of strict java comple for javadoc, for java8 -->
+    <profiles>
+        <profile>
+            <id>disable-java8-doclint</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <additionalparam>-Xdoclint:none</additionalparam>
+            </properties>
+        </profile>
+    </profiles>
     <!--
 
     There exist several targets which are by default empty and which can be 

--- a/extensions/Zay-ES-Net/src/main/java/com/simsilica/es/net/StringIdMessage.java
+++ b/extensions/Zay-ES-Net/src/main/java/com/simsilica/es/net/StringIdMessage.java
@@ -44,7 +44,7 @@ import com.jme3.network.serializing.Serializable;
  *  Used for requesting StringIndex lookups or responding
  *  to them.  Whatever is filled out in this message is used
  *  to lookup the other value and reply.  We can get away with
- *  this because string ID lookups only go client->server.
+ *  this because string ID lookups only go client-&gt;server.
  *
  *  @author    Paul Speed
  */


### PR DESCRIPTION
Hi, having a compile error which is solved in the build.xml turning off doclint for java8. Hope it is the right way. Here is the ref: http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html. Dont mind the build.xml, that was a mistake :)