### PR TITLE
Fixes known bug where EntitySets include entities that don't match the filter criteria

### DIFF
--- a/extensions/Zay-ES-Net/src/main/java/com/simsilica/es/client/RemoteEntityData.java
+++ b/extensions/Zay-ES-Net/src/main/java/com/simsilica/es/client/RemoteEntityData.java
@@ -603,6 +603,10 @@ public class RemoteEntityData implements EntityData {
                         log.trace("Entity is missing type " + getTypes()[i] + " so is not complete for this set.");
                     }
                     return false;                     
+                } else if (getMainFilter() != null && getMainFilter().getComponentType().equals(array[i].getClass())) {
+                    if (getMainFilter().evaluate(array[i])) {
+                        return false;
+                    }
                 } else {
                     // Nothing to see here
                 }


### PR DESCRIPTION
This pull request fixes the bug described in:

https://hub.jmonkeyengine.org/t/zay-es-bug-in-multiplayer-entities-are-in-the-wrong-sets/39954/47