### PR TITLE
Reverted HostedEntityData.getStringInfo() to send -1 instead of null

### DIFF
--- a/extensions/Zay-ES-Net/src/main/java/com/simsilica/es/client/RemoteStringIndex.java
+++ b/extensions/Zay-ES-Net/src/main/java/com/simsilica/es/client/RemoteStringIndex.java
@@ -96,7 +96,7 @@ public class RemoteStringIndex implements StringIndex {
             
             // Else ask remote
             result = remote.getStringId(s);
-            if( result != null ) {
+            if( result > 0 ) {
                 idIndex.put(s, result);
                 stringIndex.put(result, s);
                 return result;

--- a/extensions/Zay-ES-Net/src/main/java/com/simsilica/es/server/HostedEntityData.java
+++ b/extensions/Zay-ES-Net/src/main/java/com/simsilica/es/server/HostedEntityData.java
@@ -340,9 +340,8 @@ public class HostedEntityData {
             source.send(new StringIdMessage(msg.getRequestId(), 
                                             ed.getStrings().getString(msg.getId())));   
         } else if( msg.getString() != null ) {
-            int stringId = ed.getStrings().getStringId(msg.getString(), false);
             source.send(new StringIdMessage(msg.getRequestId(), 
-                                            stringId != -1 ? stringId : null));   
+                                            ed.getStrings().getStringId(msg.getString(), false)));   
         } else {
             throw new RuntimeException("Bad StringIdMessage:" + msg);
         }


### PR DESCRIPTION
...to prevent NPE in StringIdMessage constructor which won’t take null because it wants to unbox the object.
I think it’s better to let the -1 through and then make sure the client detects it and doesn’t cache the value.