### PR TITLE
Added a SqlComponentFactory interface to let user provide a custom fa…

### DIFF
--- a/src/main/java/com/simsilica/es/sql/FieldTypes.java
+++ b/src/main/java/com/simsilica/es/sql/FieldTypes.java
@@ -196,7 +196,19 @@ public class FieldTypes {
                 throw new RuntimeException("Error in field mapping", e);
             }
         }
-        
+
+        @Override
+        public int readIntoArray(Object[] store, int storeIndex, ResultSet rs, int columnIndex) throws SQLException {
+            Number value = (Number)rs.getObject(columnIndex++);
+
+            if( value != null ) {
+                store[storeIndex] = new EntityId(value.longValue());
+            } else {
+                store[storeIndex] = null;
+            }
+            return columnIndex;
+        }
+
         @Override
         public String toString() {
             if( dbFieldName != name ) {
@@ -282,6 +294,12 @@ public class FieldTypes {
             }
         }
         
+        @Override
+        public int readIntoArray(Object[] store, int storeIndex, ResultSet rs, int columnIndex) throws SQLException {
+            store[storeIndex] = rs.getObject(columnIndex++);
+            return columnIndex;
+        }
+
         @Override
         public String toString() {
             if( dbFieldName != name ) {
@@ -375,6 +393,22 @@ public class FieldTypes {
             }
         }
         
+        @Override
+        public int readIntoArray(Object[] store, int storeIndex, ResultSet rs, int columnIndex) throws SQLException {
+            try {
+                Object subValue = field.getType().newInstance();
+
+                for( FieldType t : fields ) {
+                    columnIndex = t.load(subValue, rs, columnIndex);
+                }
+
+                store[storeIndex] = subValue;
+                return columnIndex;
+            } catch(InstantiationException | IllegalAccessException e ) {
+                throw new RuntimeException("Error in field mapping", e);
+            }
+        }
+
         @Override
         public String toString() {
             return getFieldName() + ":" + getType() + "{" + Arrays.asList(fields) + "}";
@@ -473,7 +507,19 @@ public class FieldTypes {
                 throw new RuntimeException("Error in field mapping", e);
             }
         }
-        
+
+        @Override
+        public int readIntoArray(Object[] store, int storeIndex, ResultSet rs, int columnIndex) throws SQLException {
+            Object value = rs.getObject(columnIndex++);
+
+            if( value instanceof Number ) {
+                value = cast((Number)value, getType());
+            }
+
+            store[storeIndex] = value;
+            return columnIndex;
+        }
+
         @Override
         public String toString() {
             if( dbFieldName != name ) {

--- a/src/main/java/com/simsilica/es/sql/SqlComponentFactory.java
+++ b/src/main/java/com/simsilica/es/sql/SqlComponentFactory.java
@@ -1,7 +1,7 @@
 /*
  * $Id$
  *
- * Copyright (c) 2011-2013 jMonkeyEngine
+ * Copyright (c) 2011-2023 jMonkeyEngine
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,30 +34,15 @@
 
 package com.simsilica.es.sql;
 
-import java.sql.*;
-import java.util.*;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 /**
- *
- *  @author    Paul Speed
+ * @author Ali-RS
  */
-public interface FieldType {
+public interface SqlComponentFactory<T> {
 
-    public String getFieldName();
-    
-    public Class getType();
- 
-    public String getDbType();
+    public FieldType[] getFieldTypes();
 
-    public void addFieldDefinitions( String prefix, Map<String,FieldType> defs );
-    
-    public void addFields( String prefix, List<String> fields );
- 
-    public Object toDbValue( Object o );
-    
-    public int store( Object object, PreparedStatement ps, int index ) throws SQLException;
-    
-    public int load( Object target, ResultSet rs, int index ) throws SQLException;
-
-    public int readIntoArray( Object[] store, int storeIndex, ResultSet rs, int columnIndex ) throws SQLException;
+    public T createComponent(ResultSet rs) throws SQLException;
 }

--- a/src/main/java/com/simsilica/es/sql/SqlComponentHandler.java
+++ b/src/main/java/com/simsilica/es/sql/SqlComponentHandler.java
@@ -63,6 +63,17 @@ public class SqlComponentHandler<T extends EntityComponent> implements Component
             throw new RuntimeException("Error creating table for component type:" + type, e);
         }
     }
+
+    public SqlComponentHandler( SqlEntityData parent, Class<T> type, SqlComponentFactory<T> factory ) {
+        this.parent = parent;
+        this.type = type;
+        try {
+            this.table = new ComponentTable<>(type, factory);
+            table.initialize(parent.getSession());
+        } catch( SQLException e ) {
+            throw new RuntimeException("Error creating table for component type:" + type, e);
+        }
+    }
     
     protected SqlSession getSession() throws SQLException {
         return parent.getSession();

--- a/src/main/java/com/simsilica/es/sql/SqlEntityData.java
+++ b/src/main/java/com/simsilica/es/sql/SqlEntityData.java
@@ -95,6 +95,12 @@ public class SqlEntityData extends DefaultEntityData implements PersistentEntity
         }   
         persistentTypes.add(type);
     }
+
+    public <T extends EntityComponent> void markPersistentType( Class<T> type, SqlComponentFactory<T> factory ) {
+        markPersistentType(type);
+
+        super.registerComponentHandler(type, new SqlComponentHandler<>(this, type, factory));
+    }
  
     protected void execute( String statement ) throws SQLException {
         SqlSession session = getSession();
@@ -129,9 +135,13 @@ public class SqlEntityData extends DefaultEntityData implements PersistentEntity
     @Override
     protected <T extends EntityComponent> ComponentHandler<T> lookupDefaultHandler( Class<T> type ) {
         if( PersistentComponent.class.isAssignableFrom(type) || persistentTypes.contains(type) ) {
-            return new SqlComponentHandler<T>(this, type);
+            return new SqlComponentHandler<T>(this, type, lookupDefaultFactory(type));
         }
         return super.lookupDefaultHandler(type);
+    }
+
+    protected <T extends EntityComponent> SqlComponentFactory<T> lookupDefaultFactory( Class<T> type ) {
+        return new DefaultComponentFactory<>(type);
     }
  
     @Override


### PR DESCRIPTION
…ctory for loading sql components, the default implementation instantiates the class using a no-arg constructor and uses reflection to load fields. Also added FieldType.readIntoArray() method to let us read fields from sql results into an array instead of applying them directly to the target object. These changes should let the user expand the API to support Java Records in sql components.

Forum topic:
https://hub.jmonkeyengine.org/t/persistentcomponent-with-java-records-deserializing-issue/46885